### PR TITLE
limit "engines" to <8

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A lightweight module for code tracing using async-wrap",
   "main": "index.js",
   "engines": {
-    "node": ">=5.0.0"
+    "node": ">=5.0.0 <8"
   },
   "scripts": {
     "lint": "eslint lib/*.js test/*.js index.js",


### PR DESCRIPTION
With the introduction of `async-hooks` in v8.x, there should be a way to do this without `process.binding('async_wrap');`